### PR TITLE
fixed header verification for incoming block

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -298,13 +298,9 @@ func (a *Aura) verifyCascadingFields(chain consensus.ChainHeaderReader, header *
 	} else {
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
-	if parent == nil || parent.Number.Uint64() != number-1 || parent.Hash() != header.ParentHash {
+	if parent == nil || parent.Number.Uint64() != number-1 {
 		return consensus.ErrUnknownAncestor
 	}
-	if parent.Time > header.Time {
-		return errInvalidTimestamp
-	}
-
 	// All basic checks passed, verify the seal and return
 	return a.verifySeal(chain, header, parents)
 }


### PR DESCRIPTION
Issue scenario -
1. geth nodes with one validator
2. node0 was only validator in this scenario
3. started two nodes node0 and node1 successfully and they get peers. 
4. After that, node1 started mining but it failed to mine because node0 was the validator.
5. Then node0 started mining and announced block 1 but node1 failed to verify the block 1. Given error - unknown ancestor

Fixed this issue
