### PR TITLE
Fix: Panic from parity sync

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -23,7 +23,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/p2p"
 	"io"
+	"io/ioutil"
 	"math/big"
 	"sync"
 	"time"
@@ -722,6 +724,45 @@ func (a *Aura) CountClosestTurn(unixTimeToCheck int64, timeTolerance int64) (
 	}
 
 	err = errInvalidSigner
+
+	return
+}
+
+// This allows you to safely decode p2p message into desired headers
+// It is created, because multiple clients can have various rlp encoding/decoding mechanisms
+// For MixDigest and Nonce will produce error in decoding from parity,
+// so it would be great to have one place to decode those
+// It leaves no error, just simply empty headers set
+func HeadersFromP2PMessage(msg p2p.Msg) (headers []*types.Header) {
+	var (
+		bufferCopy  bytes.Buffer
+		auraHeaders []*types.AuraHeader
+		tempBytes   []byte
+	)
+	tee := io.TeeReader(msg.Payload, &bufferCopy)
+	readBytes, err := ioutil.ReadAll(tee)
+	err = rlp.Decode(bytes.NewReader(readBytes), &headers)
+
+	// Now run read of whole message, to do not have any leftovers
+	_, _ = msg.Payload.Read(tempBytes)
+
+	// Early return, we have read all the headers
+	if nil == err {
+		return
+	}
+
+	log.Warn("Encountered error in aura incoming header", "err", err)
+	// Remove invalid headers
+	headers = make([]*types.Header, 0)
+
+	// Fallback as auraHeaders
+	err = rlp.Decode(bytes.NewReader(readBytes), &auraHeaders)
+
+	for _, header := range auraHeaders {
+		if nil == err && nil != header {
+			headers = append(headers, header.TranslateIntoHeader())
+		}
+	}
 
 	return
 }

--- a/consensus/aura/aura_test.go
+++ b/consensus/aura/aura_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	lru "github.com/hashicorp/golang-lru"
@@ -280,6 +281,39 @@ func TestAura_FromBlock(t *testing.T) {
 	auraBlock := &types.AuraBlock{}
 	err = auraBlock.FromBlock(standardBlock)
 	assert.Nil(t, err)
+}
+
+func TestHeadersFromP2PMessage(t *testing.T) {
+	msg4Node0 := "f90241f9023ea02778716827366f0a5479d7a907800d183c57382fa7142b84fbb71db143cf788ca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479470ad1a5fba52e27173d23ad87ad97c9bbe249abfa040cf4430ecaa733787d1a65154a3b9efb560c95d9e324a23b97f0609b539133ba056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090ffffffffffffffffffffffffeceb197b0183222aa980845f6880949cdb830300018c4f70656e457468657265756d86312e34332e31826c69841314e684b84179d277eb6b97d25776793c1a98639d8d41da413fba24c338ee83bff533eac3695a0afaec6df1b77a48681a6a995798964adec1bb406c91b6bbe35f115a828a4101"
+	//headers := make([]*types.Header, 0)
+	input, err := hex.DecodeString(msg4Node0)
+	assert.Nil(t, err)
+	msg := p2p.Msg{
+		Code:       0x04,
+		Size:       uint32(len(input)),
+		Payload:    bytes.NewReader(input),
+		ReceivedAt: time.Time{},
+	}
+	headers := HeadersFromP2PMessage(msg)
+	assert.Len(t, headers, 1)
+
+	header1 := headers[0]
+	auraHeader := types.AuraHeader{}
+	err = auraHeader.FromHeader(header1)
+	assert.Nil(t, err)
+	auraHeaders := make([]*types.AuraHeader, 1)
+	auraHeaders[0] = &auraHeader
+	encodedBytes, err := rlp.EncodeToBytes(auraHeaders)
+	assert.Nil(t, err)
+	msg1 := p2p.Msg{
+		Code:       0x04,
+		Size:       uint32(len(encodedBytes)),
+		Payload:    bytes.NewReader(encodedBytes),
+		ReceivedAt: time.Time{},
+	}
+	headers = make([]*types.Header, 0)
+	headersFromAura := HeadersFromP2PMessage(msg1)
+	assert.Len(t, headersFromAura, 1)
 }
 
 func TestAura_VerifySeal(t *testing.T) {


### PR DESCRIPTION
Now we can handle std headers and aura headers at once

Scenario:
Running geth and parity AuraEngine will panic due to the fact that rlp works in other way. 
This fix allows us to handle both geth and parity types without panic

```
WARN [11-18|12:03:30.322] Encountered error in aura incoming header err="rlp: input string too short for common.Hash, decoding into ([]*types.Header)[0].MixDigest"
DEBUG[11-18|12:03:30.322] Removing Ethereum peer                   peer=87e83ea9e044008d
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0xd87b36]

goroutine 96 [running]:
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).handleMsg(0xc000048b00, 0xc000330340, 0x0, 0x0)
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/eth/handler.go:551 +0x4b96
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).handle(0xc000048b00, 0xc000330340, 0x0, 0x0)
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/eth/handler.go:374 +0x8ed
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).runPeer(0xc000048b00, 0xc000330340, 0x0, 0x0)
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/eth/handler.go:305 +0xbc
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).makeProtocol.func1(0xc0002fd920, 0x1518a00, 0xc0003a4be0, 0x0, 0x0)
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/eth/handler.go:221 +0xca
github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1(0xc0002fd920, 0xc0003a4be0, 0x1518a00, 0xc0003a4be0)
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/p2p/peer.go:370 +0x98
created by github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols
	/home/b/p/go/src/github.com/lukso-network/go-ethereum/p2p/peer.go:368 +0x205

```