### PR TITLE
This is fix for invalid header from cache that led to desynchronizati…

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -273,8 +273,6 @@ func (a *Aura) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 		return errInvalidUncleHash
 	}
 
-	log.Debug("Header difficulty and config difficulty", "header.Difficulty", header.Difficulty, "Aura.GetDifficulty", chain.Config().Aura.GetDifficulty())
-
 	// If all checks passed, validate any special fields for hard forks
 	if err := misc.VerifyForkHashes(chain.Config(), header, false); err != nil {
 		return err


### PR DESCRIPTION
Backstory:
Reopening from another solution branch: https://github.com/lukso-network/go-ethereum-aura/pull/34




Issue scenario -
1. geth nodes with one validator
2. node0 was only validator in this scenario
3. started two nodes node0 and node1 successfully and they get peers. 
4. After that, node1 started mining but it failed to mine because node0 was the validator.
5. Then node0 started mining and announced block 1 but node1 failed to verify the block 1. Given error - unknown ancestor

