### PR TITLE
Fixed invalid header delivery and wrong difficulty

### DIFF
--- a/consensus/aura/aura.go
+++ b/consensus/aura/aura.go
@@ -459,6 +459,11 @@ func (a *Aura) Prepare(chain consensus.ChainHeaderReader, header *types.Header) 
 		maxBig128 := maxInt.Sqrt(math.MaxBig256)
 		diff = big.NewInt(int64(parentStep - step + emptyStepsLen))
 		diff = diff.Add(maxBig128, diff)
+
+		if diff.Cmp(maxBig128) == 1 {
+			diff = maxBig128
+		}
+
 		return
 	}
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -337,10 +337,20 @@ func (auraHeader *AuraHeader) FromHeader(header *Header) (err error) {
 		return
 	}
 
-	if len(header.Seal[0]) != 8 {
+	sealStepCheck := func()bool { return len(header.Seal[0]) == 8 }
+	genesisBlockCheck := header.Number.Uint64() == 0
+
+	if genesisBlockCheck && !sealStepCheck() {
+		stepBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(stepBytes, 0)
+		header.Seal[0] = stepBytes
+	}
+
+	if !sealStepCheck() {
 		err = fmt.Errorf("expected 8 bytes in step")
 		return
 	}
+
 
 	auraHeader.ParentHash = header.ParentHash
 	auraHeader.UncleHash = header.UncleHash

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -503,7 +503,25 @@ func (p *peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
+// SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
+	if len(headers) > 0 && len(headers[0].Seal) > 0 {
+		auraHeaders := make([]*types.AuraHeader, 0)
+
+		for _, header := range headers {
+			auraHeader := types.AuraHeader{}
+			err := auraHeader.FromHeader(header)
+
+			if nil != err {
+				panic(err)
+			}
+
+			auraHeaders = append(auraHeaders, &auraHeader)
+		}
+
+		return p2p.Send(p.rw, BlockHeadersMsg, auraHeaders)
+	}
+
 	return p2p.Send(p.rw, BlockHeadersMsg, headers)
 }
 

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -505,24 +505,24 @@ func (p *peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	if len(headers) > 0 && len(headers[0].Seal) > 0 {
-		auraHeaders := make([]*types.AuraHeader, 0)
+	if len(headers) < 1 || len(headers[0].Seal) < 2 {
+        return p2p.Send(p.rw, BlockHeadersMsg, headers)
+    }
 
-		for _, header := range headers {
-			auraHeader := types.AuraHeader{}
-			err := auraHeader.FromHeader(header)
+    auraHeaders := make([]*types.AuraHeader, 0)
 
-			if nil != err {
-				panic(err)
-			}
+    for _, header := range headers {
+        auraHeader := types.AuraHeader{}
+        err := auraHeader.FromHeader(header)
 
-			auraHeaders = append(auraHeaders, &auraHeader)
-		}
+        if nil != err {
+    	    panic(err)
+        }
 
-		return p2p.Send(p.rw, BlockHeadersMsg, auraHeaders)
-	}
+        auraHeaders = append(auraHeaders, &auraHeader)
+    }
 
-	return p2p.Send(p.rw, BlockHeadersMsg, headers)
+    return p2p.Send(p.rw, BlockHeadersMsg, auraHeaders)
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.


### PR DESCRIPTION
Scenario:
Parity could not accept blocks sent from geth during synchronization (propagation was working fine bidirectional)

Geth was sending wrong header data, the issue was in incorrect Step interpretation (0x as `nil` instead of 0) and difficulty (value was overflowing Rust int128 datatype)

This fix prevents integer overflow and creates proper, zero-filled step (if it's set to 0 in genesis).